### PR TITLE
Infer JSON Schema with properties as type object

### DIFF
--- a/README.org
+++ b/README.org
@@ -3,7 +3,7 @@
 *tl;dr*: OooapI implements a solution to this problem:
 
 #+begin_src
-spec:'OpenAPI spec' -> 'OCaml client library for'(spec)
+spec:'OpenAPI spec' -> 'client library for'(spec):OCaml
 #+end_src
 
 * Overview

--- a/test/openai-blackbox.t/test_openai.ml
+++ b/test/openai-blackbox.t/test_openai.ml
@@ -15,7 +15,7 @@ let main =
     | Ok data ->
         let* () = Lwt_io.printl "list_models: OK" in
         Lwt_list.iter_s
-          (fun s -> Yojson.Safe.to_string s |> Lwt_io.printl)
+          (fun (m : Data.Model.t) -> Lwt_io.printl m.id)
           data.data
     | Error (`Request (_, s)) ->
         let* () = Lwt_io.printl "list_models: request failed" in

--- a/vendor/json-data-encoding/src/json_schema.ml
+++ b/vendor/json-data-encoding/src/json_schema.ml
@@ -942,6 +942,9 @@ module Make (Repr : Json_repr.Repr) = struct
         (* 1. An element with a known type field and associated fields. *)
         let as_kind =
           match opt_field_view json "type" with
+          | None when Option.is_some (opt_field_view json "properties") ->
+              (* If a schema has properties but no type, we can infer it is an object *)
+              Some (element (parse_element_kind source json "object"))
           | Some (`String name) ->
               Some (element (parse_element_kind source json name))
           | Some (`A [] as k) ->


### PR DESCRIPTION
If a schema is missing a `type` but has `properties`, we can still infer that the schema is specifying an oject, rather than reverting to untyped json.