### PR TITLE
Fix representation of files in multipart

### DIFF
--- a/lib/ocaml_of_json_schema.ml
+++ b/lib/ocaml_of_json_schema.ml
@@ -30,8 +30,8 @@ let type_of_string_specs
   : Json_schema.string_specs -> core_type
   = fun specs -> match specs.str_format with
     | None -> [%type: string]
-    | Some "binary" -> [%type: [`File of string | `String of string]]
-    | Some "uri" -> [%type: [`File of string | `String of string]] (* TODO special support for URIs? *)
+    | Some "binary" -> [%type: [`File of string ]]
+    | Some "uri" -> [%type: [`String of string]] (* TODO special support for URIs? *)
     | Some fmt -> failwith ("unsupported string format " ^ fmt)
 
 let rec type_of_element


### PR DESCRIPTION
Multipart form fields that should only take strings indicating files now do so.